### PR TITLE
Auto-bump version

### DIFF
--- a/.github/scripts/bump_version.py
+++ b/.github/scripts/bump_version.py
@@ -1,0 +1,41 @@
+import requests
+import toml
+from packaging.version import InvalidVersion, Version
+
+# Load local version
+data = toml.load("pyproject.toml")
+local_ver = Version(data["project"]["version"])
+
+# Load PyPI versions
+pypi_versions = []
+resp = requests.get(
+    "https://pypi.org/pypi/cmstp/json",
+    timeout=10,
+    headers={"Accept-Encoding": "*"},
+)
+if resp.status_code == 200 and resp.headers.get("content-type", "").startswith(
+    "application/json"
+):
+    payload = resp.json()
+    for v in payload.get("releases", {}):
+        try:
+            pypi_versions.append(Version(v))
+        except InvalidVersion:
+            pass
+
+# Determine new version
+if pypi_versions:
+    highest = max(pypi_versions)
+    if local_ver <= highest:
+        new_version = Version(
+            f"{highest.major}.{highest.minor}.{highest.micro + 1}"
+        )
+    else:
+        new_version = local_ver
+else:
+    new_version = local_ver
+
+# Write back
+data["project"]["version"] = str(new_version)
+with open("pyproject.toml", "w") as f:
+    toml.dump(data, f)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,20 +2,59 @@ name: Publish to PyPI
 
 on:
   push:
-    branches:
-    - main
+    branches: [main]
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+      with:
+        token: ${{ secrets.PRE_COMMIT_REPO_PAT }}
+        fetch-depth: 0
+        ref: ${{ github.ref }}
+        persist-credentials: true
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
       with:
         python-version: "3.10"
-    - run: pip install build twine
-    - run: python -m build
-    - env:
+
+    - name: Install required tools
+      run: |
+        pip install build twine toml requests
+
+    # Set git user for committing changes and ensure we are on the correct branch
+    - name: Configure git
+      run: |
+        BRANCH="${GITHUB_REF#refs/heads/}"
+        echo "BRANCH=$BRANCH" >> $GITHUB_ENV
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git checkout -B "$BRANCH"
+
+    - name: Auto-bump version if needed
+      run: |
+        python .github/scripts/bump_version.py
+
+    - name: Commit bumped version
+      run: |
+        # Commit any changes made by pre-commit (if any)
+        if [ -n "$(git status --porcelain)" ]; then
+          git add pyproject.toml
+          git commit -m "Auto-bump version"
+          git push origin HEAD:"${BRANCH}"
+          echo "Committed version bump"
+        else
+          echo "No changes to commit"
+        fi
+
+    - name: Build package
+      run: python -m build
+
+    - name: Publish to PyPI
+      env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
       run: twine upload dist/*


### PR DESCRIPTION
## Description

Implements a github workflow that auto-bumps the package version in the `pyproject.toml` when a PR is merged onto main.

Closes #1 

<!-- Please add a "feature" label (and other applicable ones) via the UI -->
